### PR TITLE
Optimize rule pruning algorithm

### DIFF
--- a/src/main/java/net/seninp/gi/logic/GrammarRuleRecord.java
+++ b/src/main/java/net/seninp/gi/logic/GrammarRuleRecord.java
@@ -1,5 +1,6 @@
 package net.seninp.gi.logic;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -10,7 +11,7 @@ import java.util.Arrays;
  * @author Manfred Lerner, seninp
  * 
  */
-public class GrammarRuleRecord {
+public class GrammarRuleRecord implements Serializable {
 
   /* The rule number in Sequitur grammar. */
   private int ruleNumber;

--- a/src/main/java/net/seninp/gi/logic/GrammarRules.java
+++ b/src/main/java/net/seninp/gi/logic/GrammarRules.java
@@ -1,5 +1,6 @@
 package net.seninp.gi.logic;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.SortedMap;
@@ -11,7 +12,7 @@ import java.util.TreeMap;
  * @author psenin
  *
  */
-public class GrammarRules implements Iterable<GrammarRuleRecord> {
+public class GrammarRules implements Iterable<GrammarRuleRecord>, Serializable {
 
   private SortedMap<Integer, GrammarRuleRecord> rules;
 

--- a/src/main/java/net/seninp/gi/logic/RuleInterval.java
+++ b/src/main/java/net/seninp/gi/logic/RuleInterval.java
@@ -1,5 +1,7 @@
 package net.seninp.gi.logic;
 
+import java.io.Serializable;
+
 /**
  * 
  * Helper class implementing an interval used when plotting.
@@ -7,7 +9,7 @@ package net.seninp.gi.logic;
  * @author Manfred Lerner, seninp
  * 
  */
-public class RuleInterval implements Comparable<RuleInterval>, Cloneable {
+public class RuleInterval implements Comparable<RuleInterval>, Cloneable, Serializable {
 
   public int id; // the corresponding rule id
   public int startPos; // interval start

--- a/src/main/java/net/seninp/gi/rulepruner/RulePrunerFactory.java
+++ b/src/main/java/net/seninp/gi/rulepruner/RulePrunerFactory.java
@@ -1,11 +1,11 @@
 package net.seninp.gi.rulepruner;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import net.seninp.gi.logic.GrammarRuleRecord;
 import net.seninp.gi.logic.GrammarRules;
 import net.seninp.gi.logic.RuleInterval;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Pruner methods implementation.
@@ -21,69 +21,41 @@ public class RulePrunerFactory {
    * @param rules the grammar rules.
    * @param paaSize the SAX transform word size.
    * 
-   * @return the grammar size.
+   * @return the grammar size, in BYTES.
    */
   public static Integer computeGrammarSize(GrammarRules rules, Integer paaSize) {
 
-    // res is the final grammar's size
-    //
-    // we count BYTES
+    // The final grammar's size in BYTES
     //
     int res = 0;
 
-    // first we compute the size needed for encoding of rules
+    // The final size is the sum of the sizes of all rules
     //
     for (GrammarRuleRecord r : rules) {
-
-      int ruleSize = 0;
-
-      // Rule #0 gets the special treatment
-      //
-      if (0 == r.getRuleNumber()) {
-
-        // split the rule string onto constituting tokens
-        //
-        String ruleStr = r.getRuleString();
-        String[] tokens = ruleStr.split("\\s+");
-        for (String t : tokens) {
-          if (t.startsWith("R")) {
-            // if it is a non-terminal, i.e., another rule, we account for a 4 bytes (32 bits
-            // offset) pointer onto the rule data structure
-            ruleSize = ruleSize + 4;
-          }
-          else {
-            // if it is a terminal, account for a byte used for each letter
-            ruleSize = ruleSize + paaSize;
-            // and 4 bytes for the offset on time-series
-          }
-        }
-
-      }
-      else {
-
-        // rules... split the rule string onto constituting tokens
-        //
-        String ruleStr = r.getRuleString();
-        String[] tokens = ruleStr.split("\\s+");
-        for (String t : tokens) {
-          if (t.startsWith("R")) {
-            // the same offset for another rule
-            ruleSize = ruleSize + 4;
-          }
-          else {
-            ruleSize = ruleSize + paaSize;
-          }
-        }
-        // since we keep an array of rule occurrences we may account for these, but we don't have to
-        // since they can be recovered using R0
-        // ruleSize = ruleSize + r.getOccurrences().size() * 2;
-      }
-
-      res = res + ruleSize;
+      String ruleStr = r.getRuleString();
+      String[] tokens = ruleStr.split("\\s+");
+      int ruleSize = computeRuleSize(paaSize, tokens);
+      res += ruleSize;
     }
 
     return res;
+  }
 
+  private static int computeRuleSize(Integer paaSize, String[] tokens) {
+    int ruleSize = 0;
+    for (String t : tokens) {
+      if (t.startsWith("R")) {
+        // if it is a non-terminal, i.e., another rule, we account for a 4 bytes (32 bits
+        // offset) pointer onto the rule data structure
+        ruleSize = ruleSize + 4;
+      }
+      else {
+        // if it is a terminal, account for a byte used for each letter
+        // and 4 bytes for the offset on time-series
+        ruleSize = ruleSize + paaSize;
+      }
+    }
+    return ruleSize;
   }
 
   /**
@@ -94,181 +66,9 @@ public class RulePrunerFactory {
    * @return pruned ruleset.
    */
   public static GrammarRules performPruning(double[] ts, GrammarRules grammarRules) {
-
-    // this is where we keep the range coverage
-    boolean[] range = new boolean[ts.length];
-
-    // these are the rules used in the current cover
-    HashSet<Integer> usedRules = new HashSet<Integer>();
-    usedRules.add(0);
-
-    // these are the rules thet were excluded as not contributing anymore
-    HashSet<Integer> removedRules = new HashSet<Integer>();
-
-    // do until all ranges are covered BUT break if no more coverage left
-    while (hasEmptyRanges(range)) {
-
-      // iterate over rules set finding new optimal cover
-      //
-      GrammarRuleRecord bestRule = null;
-      double bestDelta = Integer.MIN_VALUE;
-
-      for (GrammarRuleRecord rule : grammarRules) {
-        int id = rule.getRuleNumber();
-        if (usedRules.contains(id) || removedRules.contains(id)) {
-          continue;
-        }
-        else {
-          double delta = getCoverDelta(range, rule);
-          if (delta > bestDelta) {
-            bestDelta = delta;
-            bestRule = rule;
-          }
-        }
-      }
-
-      if (bestDelta < 0) {
-        // i.e. no delta found and the value stayed Integer.MIN_VALUE
-        break;
-      }
-
-      usedRules.add(bestRule.getRuleNumber());
-
-      // check for overlap artifacts
-      //
-      boolean continueSearch = true;
-
-      while (continueSearch) {
-
-        continueSearch = false;
-
-        for (int currentRule : usedRules) { // used rules are those in the current cover
-
-          if (0 == currentRule) {
-            continue;
-          }
-
-          // a set of intervals in consideration
-          ArrayList<RuleInterval> intervalsA = grammarRules.get(currentRule).getRuleIntervals();
-
-          // a set of intervals we are going to compare with
-          ArrayList<RuleInterval> intervalsB = new ArrayList<RuleInterval>();
-
-          for (int ridB : usedRules) { // used rules are those in the current cover
-            if (0 == ridB || currentRule == ridB) {
-              continue;
-            }
-            intervalsB.addAll(grammarRules.get(ridB).getRuleIntervals());
-          }
-
-          if (intervalsB.isEmpty()) {
-            break; // this only happens with a single rule, when nothing to compare with
-          }
-          else if (isCompletlyCoveredBy(intervalsB, intervalsA)) {
-            usedRules.remove(currentRule);
-            removedRules.add(currentRule); // we would not consider it later on
-            continueSearch = true;
-            break;
-          }
-          // else {
-          // System.out.println(
-          // "rule " + grammarRules.get(currentRule).getRuleName() + " can't be removed");
-          // }
-
-        }
-      }
-
-      // add the new candidate and keep the track of cover
-      //
-      range = updateRanges(range, bestRule.getRuleIntervals());
-    }
-
-    // System.out.println("Best cover "
-    // + Arrays.toString(usedRules.toArray(new Integer[usedRules.size()])));
-
-    GrammarRules prunedRules = new GrammarRules();
-
-    // regularize pruned rules
-    //
-    for (Integer rId : usedRules) {
-      String oldRuleStr = grammarRules.get(rId).getRuleString();
-      StringBuffer newRuleStr = new StringBuffer();
-      String[] tokens = oldRuleStr.split("\\s+");
-      for (String t : tokens) {
-        if (t.startsWith("R")) {
-          Integer ruleId = Integer.valueOf(t.substring(1));
-          if (usedRules.contains(ruleId)) {
-            newRuleStr.append(t).append(" ");
-          }
-          else {
-            // System.err.println("updating the rule " + rId);
-            newRuleStr.append(resolve(ruleId, usedRules, grammarRules)).append(" ");
-          }
-        }
-        else {
-          newRuleStr.append(t).append(" ");
-        }
-      }
-      if (newRuleStr.length() > 0) {
-        newRuleStr.delete(newRuleStr.length() - 1, newRuleStr.length());
-      }
-      GrammarRuleRecord regRule = grammarRules.get(rId);
-      regRule.setRuleString(newRuleStr.toString());
-      prunedRules.addRule(regRule);
-    }
-
-    // process the R0 for discrepancies
-    //
-    // split the rule string onto constituting tokens
-    //
-    // String ruleStr = grammarRules.get(0).getRuleString();
-    // StringBuffer newRuleString = new StringBuffer();
-    // String[] tokens = ruleStr.split("\\s+");
-    // for (String t : tokens) {
-    // if (t.startsWith("R")) {
-    // Integer rId = Integer.valueOf(t.substring(1));
-    // if (usedRules.contains(rId)) {
-    // newRuleString.append(t).append(" ");
-    // }
-    // // else {
-    // // System.err.println("removed rule " + rId + " from R0");
-    // // }
-    // }
-    // }
-    // if (newRuleString.length() > 0) {
-    // newRuleString.delete(newRuleString.length() - 1, newRuleString.length());
-    // }
-    // GrammarRuleRecord newR0 = new GrammarRuleRecord();
-    // newR0.setRuleNumber(0);
-    // newR0.setRuleString(newRuleString.toString());
-
-    return prunedRules;
-
-  }
-
-  private static String resolve(Integer ruleId, HashSet<Integer> usedRules,
-      GrammarRules grammarRules) {
-    String currentString = grammarRules.get(ruleId).getRuleString();
-    StringBuffer newString = new StringBuffer();
-    String[] tokens = currentString.split("\\s+");
-    for (String t : tokens) {
-      if (t.startsWith("R")) {
-        Integer rId = Integer.valueOf(t.substring(1));
-        if (usedRules.contains(rId)) {
-          newString.append(t).append(" ");
-        }
-        else {
-          newString.append(resolve(rId, usedRules, grammarRules)).append(" ");
-        }
-      }
-      else {
-        newString.append(t).append(" ");
-      }
-    }
-    if (newString.length() > 0) {
-      newString.delete(newString.length() - 1, newString.length());
-    }
-    return newString.toString();
+    RulePruningAlgorithm pruner = new RulePruningAlgorithm(grammarRules, ts.length);
+    pruner.pruneRules();
+    return pruner.regularizePrunedRules();
   }
 
   // /**
@@ -368,68 +168,6 @@ public class RulePrunerFactory {
   // }
 
   /**
-   * Checks if the cover is complete.
-   * 
-   * @param cover the cover.
-   * @param intervals set of rule intervals.
-   * @return true if the set complete.
-   */
-  public static boolean isCompletlyCoveredBy(ArrayList<RuleInterval> cover,
-      ArrayList<RuleInterval> intervals) {
-
-    // first we build an array of intervals
-    //
-    int min = intervals.get(0).getStart();
-    int max = intervals.get(0).getEnd();
-    for (RuleInterval i : intervals) {
-      if (i.getStart() < min) {
-        min = i.getStart();
-      }
-      if (i.getEnd() > max) {
-        max = i.getEnd();
-      }
-    }
-    boolean[] isNotCovered = new boolean[max - min]; // all a false on the init
-    for (RuleInterval i : intervals) {
-      for (int j = i.getStart(); j < i.getEnd(); j++) {
-        isNotCovered[j - min] = true; // this is covered by the selection BUTnot by cover yet
-      }
-    }
-
-    // so now here we have the range where true value correspond to the ranges belonging to
-    // "intervals", which we effectively checking for being covered by cover
-    //
-    // true means uncovered
-    //
-
-    for (RuleInterval i : cover) {
-
-      for (int j = i.getStart(); j < i.getEnd(); j++) {
-
-        if (j < min || j >= max) {
-          continue;
-        }
-        else if (isNotCovered[j - min]) {
-          isNotCovered[j - min] = false;
-        }
-
-      }
-
-    }
-
-    // int ctr = 0;
-    for (boolean b : isNotCovered) {
-      if (b) {
-        // System.out.println("not covered: " + (min + ctr));
-        return false;
-      }
-      // ctr++;
-    }
-
-    return true;
-  }
-
-  /**
    * Updating the coverage ranges.
    * 
    * @param range the global range array.
@@ -468,53 +206,6 @@ public class RulePrunerFactory {
   }
 
   /**
-   * Computes the delta value for the suggested rule candidate.
-   * 
-   * @param range the range we compute the cover delta for.
-   * @param rule the grammatical rule candidate.
-   * 
-   * @return the delta value.
-   */
-  public static double getCoverDelta(boolean[] range, GrammarRuleRecord rule) {
-
-    // counts which uncovered points shall be covered
-    int new_cover = 0;
-
-    // counts overlaps with previously covered ranges
-    int overlapping_cover = 0;
-
-    // perform the sum computation
-    for (RuleInterval i : rule.getRuleIntervals()) {
-      int start = i.getStart();
-      int end = i.getEnd();
-      for (int j = start; j < end; j++) {
-        if (range[j]) {
-          overlapping_cover++;
-        }
-        else {
-          new_cover++;
-        }
-      }
-    }
-
-    // if covers nothing, return 0
-    if (0 == new_cover) {
-      return 0.0;
-    }
-
-    // if zero overlap, return full weighted cover
-    if (0 == overlapping_cover) {
-      return (double) new_cover
-          / (double) (rule.getExpandedRuleString().length() + rule.getRuleIntervals().size());
-    }
-
-    // else divide newly covered points amount by the sum of the rule string length and occurrence
-    // (i.e. encoding size)
-    return ((double) new_cover / (double) (new_cover + overlapping_cover))
-        / (double) (rule.getExpandedRuleString().length() + rule.getRuleIntervals().size());
-  }
-
-  /**
    * Compute the covered percentage.
    * 
    * @param cover the cover array.
@@ -538,7 +229,7 @@ public class RulePrunerFactory {
    */
   public static boolean isCovered(boolean[] range) {
     for (boolean i : range) {
-      if (false == i) {
+      if (!i) {
         return false;
       }
     }
@@ -576,11 +267,10 @@ public class RulePrunerFactory {
     //
     //
     for (boolean p : range) {
-      if (false == p) {
+      if (!p) {
         return true;
       }
     }
     return false;
   }
-
 }

--- a/src/main/java/net/seninp/gi/rulepruner/RulePrunerFactory.java
+++ b/src/main/java/net/seninp/gi/rulepruner/RulePrunerFactory.java
@@ -4,8 +4,8 @@ import net.seninp.gi.logic.GrammarRuleRecord;
 import net.seninp.gi.logic.GrammarRules;
 import net.seninp.gi.logic.RuleInterval;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Pruner methods implementation.
@@ -174,7 +174,7 @@ public class RulePrunerFactory {
    * @param ruleIntervals The intervals used for this update.
    * @return an updated array.
    */
-  public static boolean[] updateRanges(boolean[] range, ArrayList<RuleInterval> ruleIntervals) {
+  public static boolean[] updateRanges(boolean[] range, List<RuleInterval> ruleIntervals) {
     boolean[] res = Arrays.copyOf(range, range.length);
     for (RuleInterval i : ruleIntervals) {
       int start = i.getStart();

--- a/src/main/java/net/seninp/gi/rulepruner/RulePruningAlgorithm.java
+++ b/src/main/java/net/seninp/gi/rulepruner/RulePruningAlgorithm.java
@@ -1,0 +1,304 @@
+package net.seninp.gi.rulepruner;
+
+import net.seninp.gi.logic.GrammarRuleRecord;
+import net.seninp.gi.logic.GrammarRules;
+import net.seninp.gi.logic.RuleInterval;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Implement algorithm for pruning rules based on optimal covering search.
+ */
+public class RulePruningAlgorithm {
+
+  private static Logger logger = LoggerFactory.getLogger(RulePruningAlgorithm.class);
+
+  private GrammarRules grammarRules;
+  private boolean[] range;
+  private Set<Integer> usedRules;
+  private Set<Integer> removedRules;
+
+  public RulePruningAlgorithm(GrammarRules grammarRules, int tsLength) {
+    this.grammarRules = grammarRules;
+    this.range = new boolean[tsLength];
+
+    // these are the rules used in the current cover
+    this.usedRules = new HashSet<>();
+    usedRules.add(0);
+
+    // these are the rules that were excluded as not contributing anymore
+    this.removedRules = new HashSet<>();
+  }
+
+  public void pruneRules() {
+    // do until all ranges are covered BUT break if no more coverage left
+    while (RulePrunerFactory.hasEmptyRanges(range)) {
+
+      GrammarRuleRecord bestRule = this.findRuleWithOptimalCover();
+      if (bestRule == null) {
+        // i.e. no delta found; no more coverage left
+        break;
+      }
+
+      usedRules.add(bestRule.getRuleNumber());
+      this.removeOverlappingRules();
+
+      // add the new candidate and keep the track of cover
+      range = RulePrunerFactory.updateRanges(range, bestRule.getRuleIntervals());
+    }
+
+    if (logger.isDebugEnabled()) {
+      String rulesAsStrings = Arrays.toString(usedRules.toArray(new Integer[usedRules.size()]));
+      logger.debug("Best cover {}", rulesAsStrings);
+    }
+  }
+
+  /**
+   * @return rule with optimal cover, or null if none found (no more coverage left).
+   */
+  private GrammarRuleRecord findRuleWithOptimalCover() {
+    GrammarRuleRecord bestRule = null;
+    double bestDelta = Integer.MIN_VALUE;
+
+    for (GrammarRuleRecord rule : grammarRules) {
+      int id = rule.getRuleNumber();
+      if (!usedRules.contains(id) && !removedRules.contains(id)) {
+        double delta = this.getCoverDelta(rule);
+        if (delta > bestDelta) {
+          bestDelta = delta;
+          bestRule = rule;
+        }
+      }
+    }
+    return bestRule;
+  }
+
+  /**
+   * Computes the delta value for the suggested rule candidate.
+   *
+   * @param rule the grammatical rule candidate.
+   * @return the delta value.
+   */
+  public double getCoverDelta(GrammarRuleRecord rule) {
+
+    // counts which uncovered points shall be covered
+    int new_cover = 0;
+
+    // counts overlaps with previously covered ranges
+    int overlapping_cover = 0;
+
+    // perform the sum computation
+    for (RuleInterval i : rule.getRuleIntervals()) {
+      int start = i.getStart();
+      int end = i.getEnd();
+      for (int j = start; j < end; j++) {
+        if (range[j]) {
+          overlapping_cover++;
+        }
+        else {
+          new_cover++;
+        }
+      }
+    }
+
+    // if covers nothing, return 0
+    if (0 == new_cover) {
+      return 0.0;
+    }
+
+    // if zero overlap, return full weighted cover
+    if (0 == overlapping_cover) {
+      return (double) new_cover
+              / (double) (rule.getExpandedRuleString().length() + rule.getRuleIntervals().size());
+    }
+
+    // else divide newly covered points amount by the sum of the rule string length and occurrence
+    // (i.e. encoding size)
+    return ((double) new_cover / (double) (new_cover + overlapping_cover))
+            / (double) (rule.getExpandedRuleString().length() + rule.getRuleIntervals().size());
+  }
+
+  private void removeOverlappingRules() {
+    boolean continueSearch = true;
+    while (continueSearch) {
+      continueSearch = false;
+
+      for (int currentRule : usedRules) { // used rules are those in the current cover
+        if (0 == currentRule) {
+          continue;
+        }
+
+        // a set of intervals in consideration
+        List<RuleInterval> intervalsA = grammarRules.get(currentRule).getRuleIntervals();
+
+        // a set of intervals we are going to compare with
+        List<RuleInterval> intervalsB = new ArrayList<>();
+
+        for (int ridB : usedRules) { // used rules are those in the current cover
+          if (0 == ridB || currentRule == ridB) {
+            continue;
+          }
+          intervalsB.addAll(grammarRules.get(ridB).getRuleIntervals());
+        }
+
+        if (intervalsB.isEmpty()) {
+          break; // this only happens with a single rule, when nothing to compare with
+        }
+        if (this.isCompletelyCoveredBy(intervalsB, intervalsA)) {
+          usedRules.remove(currentRule);
+          removedRules.add(currentRule); // we would not consider it later on
+          continueSearch = true;
+          break;
+        }
+        // else {
+        // System.out.println(
+        // "rule " + grammarRules.get(currentRule).getRuleName() + " can't be removed");
+        // }
+
+      }
+    }
+  }
+
+  /**
+   * Checks if the cover is complete.
+   *
+   * @param cover the cover.
+   * @param intervals set of rule intervals.
+   * @return true if the set complete.
+   */
+  private boolean isCompletelyCoveredBy(List<RuleInterval> cover, List<RuleInterval> intervals) {
+
+    // first we build an array of intervals
+    //
+    int min = intervals.get(0).getStart();
+    int max = intervals.get(0).getEnd();
+    for (RuleInterval i : intervals) {
+      if (i.getStart() < min) {
+        min = i.getStart();
+      }
+      if (i.getEnd() > max) {
+        max = i.getEnd();
+      }
+    }
+    boolean[] isNotCovered = new boolean[max - min]; // all a false on the init
+    for (RuleInterval i : intervals) {
+      for (int j = i.getStart(); j < i.getEnd(); j++) {
+        isNotCovered[j - min] = true; // this is covered by the selection BUTnot by cover yet
+      }
+    }
+
+    // so now here we have the range where true value correspond to the ranges belonging to
+    // "intervals", which we effectively checking for being covered by cover
+    //
+    // true means uncovered
+    //
+    for (RuleInterval i : cover) {
+
+      for (int j = i.getStart(); j < i.getEnd(); j++) {
+        if (j < min || j >= max) {
+          continue;
+        }
+        if (isNotCovered[j - min]) {
+          isNotCovered[j - min] = false;
+        }
+      }
+    }
+
+    // int ctr = 0;
+    for (boolean b : isNotCovered) {
+      if (b) {
+        // System.out.println("not covered: " + (min + ctr));
+        return false;
+      }
+      // ctr++;
+    }
+
+    return true;
+  }
+
+  public GrammarRules regularizePrunedRules() {
+    GrammarRules prunedRules = new GrammarRules();
+
+    for (Integer rId : usedRules) {
+      StringBuilder newRuleStr = this.buildExpandedRuleString(rId);
+      if (newRuleStr.length() > 0) {
+        newRuleStr.delete(newRuleStr.length() - 1, newRuleStr.length());
+      }
+
+      GrammarRuleRecord regRule = grammarRules.get(rId);
+      regRule.setRuleString(newRuleStr.toString());
+      prunedRules.addRule(regRule);
+    }
+
+    if (logger.isDebugEnabled()) {
+      this.logRegularizationResults();
+    }
+
+    return prunedRules;
+  }
+
+  private StringBuilder buildExpandedRuleString(Integer rId) {
+    String oldRuleStr = grammarRules.get(rId).getRuleString();
+    String[] tokens = oldRuleStr.split("\\s+");
+    StringBuilder newRuleStr = new StringBuilder();
+
+    for (String t : tokens) {
+      if (t.startsWith("R")) {
+        Integer ruleId = Integer.valueOf(t.substring(1));
+        if (usedRules.contains(ruleId)) {
+          newRuleStr.append(t).append(" ");
+        } else {
+          logger.debug("updating the rule " + rId);
+          newRuleStr.append(resolve(ruleId)).append(" ");
+        }
+      } else {
+        newRuleStr.append(t).append(" ");
+      }
+    }
+
+    return newRuleStr;
+  }
+
+  private String resolve(Integer ruleId) {
+    StringBuilder newRuleStr = this.buildExpandedRuleString(ruleId);
+    if (newRuleStr.length() > 0) {
+      newRuleStr.delete(newRuleStr.length() - 1, newRuleStr.length());
+    }
+    return newRuleStr.toString();
+  }
+
+  private void logRegularizationResults() {
+    // process the R0 for discrepancies
+    //
+    // split the rule string onto constituting tokens
+    //
+    String ruleStr = grammarRules.get(0).getRuleString();
+    StringBuilder newRuleString = new StringBuilder();
+    String[] tokens = ruleStr.split("\\s+");
+    for (String t : tokens) {
+      if (t.startsWith("R")) {
+        Integer rId = Integer.valueOf(t.substring(1));
+        if (usedRules.contains(rId)) {
+          newRuleString.append(t).append(" ");
+        } else {
+          logger.debug("removed rule " + rId + " from R0");
+        }
+      }
+    }
+
+    if (newRuleString.length() > 0) {
+      newRuleString.delete(newRuleString.length() - 1, newRuleString.length());
+    }
+
+    GrammarRuleRecord newR0 = new GrammarRuleRecord();
+    newR0.setRuleNumber(0);
+    newR0.setRuleString(newRuleString.toString());
+    logger.trace(newR0.toString());
+  }
+}


### PR DESCRIPTION
This PR optimizes the rule pruning algorithm and resolves #15. The main change is to maintain an integer array with the coverage counts for each index spanned by the time series. In particular, each cell corresponds to the count of rules in the `usedRules` `Set` that currently spans that cell. To determine if a particular rule is completely covered by the other rules, it is sufficient to return as soon as we find a cell not covered by the other rules (with non-zero count in the `coverageCounts`).

With this integer array, it is no longer necessary to maintain the list of current rules, so the adding and removing from that list is replaced by methods to maintain the integer counts.

The remaining changes were an initial refactor of the `RulePrunerFactory` to pull out the `RulePruningAlgorithm` and moving various commented out code and print statements to logging statements at (what I deemed) appropriate levels.

In my testing, I found it useful to serialize a `GrammarRules` object from the grammar induction to avoid repeating the induction routine. This is why I made `GrammarRules`, `GrammarRuleRecord`, and `RuleInterval` implement `Serializable`. I also updated the GrammarViz code to add an option to write the rules in the serialized format. I am happy to put up a PR for that if/when this goes in.